### PR TITLE
Normalize composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,6 @@
 {
     "name": "laminas-api-tools/api-tools-content-negotiation",
     "description": "Laminas Module providing content-negotiation features",
-    "license": "BSD-3-Clause",
     "keywords": [
         "laminas",
         "api-tools",
@@ -9,22 +8,7 @@
         "content-negotiation"
     ],
     "homepage": "https://api-tools.getlaminas.org",
-    "support": {
-        "docs": "https://api-tools.getlaminas.org/documentation",
-        "issues": "https://github.com/laminas-api-tools/api-tools-content-negotiation/issues",
-        "source": "https://github.com/laminas-api-tools/api-tools-content-negotiation",
-        "rss": "https://github.com/laminas-api-tools/api-tools-content-negotiation/releases.atom",
-        "chat": "https://laminas.dev/chat",
-        "forum": "https://discourse.laminas.dev"
-    },
-    "config": {
-        "sort-packages": true
-    },
-    "extra": {
-        "laminas": {
-            "module": "Laminas\\ApiTools\\ContentNegotiation"
-        }
-    },
+    "license": "BSD-3-Clause",
     "require": {
         "php": "^5.6 || ^7.0",
         "laminas-api-tools/api-tools-api-problem": "^1.2.1",
@@ -39,6 +23,9 @@
         "laminas/laminas-view": "^2.8.1",
         "laminas/laminas-zendframework-bridge": "^1.0"
     },
+    "replace": {
+        "zfcampus/zf-content-negotiation": "^1.4.0"
+    },
     "require-dev": {
         "laminas-api-tools/api-tools-hal": "^1.4",
         "laminas/laminas-coding-standard": "~1.0.0",
@@ -47,6 +34,14 @@
     },
     "suggest": {
         "laminas/laminas-console": "^2.0, if you intend to use the console request of RequestFactory"
+    },
+    "config": {
+        "sort-packages": true
+    },
+    "extra": {
+        "laminas": {
+            "module": "Laminas\\ApiTools\\ContentNegotiation"
+        }
     },
     "autoload": {
         "psr-4": {
@@ -68,7 +63,12 @@
         "test": "phpunit --colors=always",
         "test-coverage": "phpunit --colors=always --coverage-clover clover.xml"
     },
-    "replace": {
-        "zfcampus/zf-content-negotiation": "^1.4.0"
+    "support": {
+        "issues": "https://github.com/laminas-api-tools/api-tools-content-negotiation/issues",
+        "forum": "https://discourse.laminas.dev",
+        "chat": "https://laminas.dev/chat",
+        "source": "https://github.com/laminas-api-tools/api-tools-content-negotiation",
+        "docs": "https://api-tools.getlaminas.org/documentation",
+        "rss": "https://github.com/laminas-api-tools/api-tools-content-negotiation/releases.atom"
     }
 }


### PR DESCRIPTION
**[QA]**
* Normalize `composer.json` and/or update `composer.lock`
    - Restructure `composer.json` according to the underlying [JSON schema](https://getcomposer.org/schema.json).
    - Prevent inconsistencies between all (200+) repositories across all 3 GitHub organizations (`laminas`, `mezzio`, and `laminas-api-tools`).