### PR TITLE
Provide Psalm integration

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -32,4 +32,4 @@ jobs:
         with:
           job: ${{ matrix.job }}
         env:
-          "GITHUB_TOKEN": ${{ secrets.GITHUB_TOKEN }}
+          "GITHUB_TOKEN": ${{ secrets.ORGANIZATION_READ_ONLY_TOKEN }}

--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,9 @@
         "laminas/laminas-coding-standard": "~2.2.0",
         "laminas/laminas-console": "^2.9",
         "phpspec/prophecy-phpunit": "^2.0",
-        "phpunit/phpunit": "^9.3"
+        "phpunit/phpunit": "^9.3",
+        "psalm/plugin-phpunit": "^0.16.0",
+        "vimeo/psalm": "^4.7"
     },
     "suggest": {
         "laminas/laminas-console": "^2.0, if you intend to use the console request of RequestFactory"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "eff0fd98aca908ef238405a113fa5ce3",
+    "content-hash": "456458c1e54ce4555b43983083ab941b",
     "packages": [
         {
             "name": "brick/varexporter",
@@ -1496,6 +1496,390 @@
     ],
     "packages-dev": [
         {
+            "name": "amphp/amp",
+            "version": "v2.5.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/amp.git",
+                "reference": "efca2b32a7580087adb8aabbff6be1dc1bb924a9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/amp/zipball/efca2b32a7580087adb8aabbff6be1dc1bb924a9",
+                "reference": "efca2b32a7580087adb8aabbff6be1dc1bb924a9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "dev-master",
+                "amphp/phpunit-util": "^1",
+                "ext-json": "*",
+                "jetbrains/phpstorm-stubs": "^2019.3",
+                "phpunit/phpunit": "^6.0.9 | ^7",
+                "psalm/phar": "^3.11@dev",
+                "react/promise": "^2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Amp\\": "lib"
+                },
+                "files": [
+                    "lib/functions.php",
+                    "lib/Internal/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Daniel Lowrey",
+                    "email": "rdlowrey@php.net"
+                },
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Bob Weinand",
+                    "email": "bobwei9@hotmail.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "A non-blocking concurrency framework for PHP applications.",
+            "homepage": "http://amphp.org/amp",
+            "keywords": [
+                "async",
+                "asynchronous",
+                "awaitable",
+                "concurrency",
+                "event",
+                "event-loop",
+                "future",
+                "non-blocking",
+                "promise"
+            ],
+            "support": {
+                "irc": "irc://irc.freenode.org/amphp",
+                "issues": "https://github.com/amphp/amp/issues",
+                "source": "https://github.com/amphp/amp/tree/v2.5.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-01-10T17:06:37+00:00"
+        },
+        {
+            "name": "amphp/byte-stream",
+            "version": "v1.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/byte-stream.git",
+                "reference": "acbd8002b3536485c997c4e019206b3f10ca15bd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/byte-stream/zipball/acbd8002b3536485c997c4e019206b3f10ca15bd",
+                "reference": "acbd8002b3536485c997c4e019206b3f10ca15bd",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^2",
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "dev-master",
+                "amphp/phpunit-util": "^1.4",
+                "friendsofphp/php-cs-fixer": "^2.3",
+                "jetbrains/phpstorm-stubs": "^2019.3",
+                "phpunit/phpunit": "^6 || ^7 || ^8",
+                "psalm/phar": "^3.11.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Amp\\ByteStream\\": "lib"
+                },
+                "files": [
+                    "lib/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "A stream abstraction to make working with non-blocking I/O simple.",
+            "homepage": "http://amphp.org/byte-stream",
+            "keywords": [
+                "amp",
+                "amphp",
+                "async",
+                "io",
+                "non-blocking",
+                "stream"
+            ],
+            "support": {
+                "irc": "irc://irc.freenode.org/amphp",
+                "issues": "https://github.com/amphp/byte-stream/issues",
+                "source": "https://github.com/amphp/byte-stream/tree/v1.8.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-03-30T17:13:30+00:00"
+        },
+        {
+            "name": "composer/package-versions-deprecated",
+            "version": "1.11.99.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/package-versions-deprecated.git",
+                "reference": "c6522afe5540d5fc46675043d3ed5a45a740b27c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/package-versions-deprecated/zipball/c6522afe5540d5fc46675043d3ed5a45a740b27c",
+                "reference": "c6522afe5540d5fc46675043d3ed5a45a740b27c",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.1.0 || ^2.0",
+                "php": "^7 || ^8"
+            },
+            "replace": {
+                "ocramius/package-versions": "1.11.99"
+            },
+            "require-dev": {
+                "composer/composer": "^1.9.3 || ^2.0@dev",
+                "ext-zip": "^1.13",
+                "phpunit/phpunit": "^6.5 || ^7"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PackageVersions\\Installer",
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PackageVersions\\": "src/PackageVersions"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be"
+                }
+            ],
+            "description": "Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
+            "support": {
+                "issues": "https://github.com/composer/package-versions-deprecated/issues",
+                "source": "https://github.com/composer/package-versions-deprecated/tree/1.11.99.2"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-05-24T07:46:03+00:00"
+        },
+        {
+            "name": "composer/semver",
+            "version": "3.2.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/semver.git",
+                "reference": "31f3ea725711245195f62e54ffa402d8ef2fdba9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/semver/zipball/31f3ea725711245195f62e54ffa402d8ef2fdba9",
+                "reference": "31f3ea725711245195f62e54ffa402d8ef2fdba9",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^0.12.54",
+                "symfony/phpunit-bridge": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Semver\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "http://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                },
+                {
+                    "name": "Rob Bast",
+                    "email": "rob.bast@gmail.com",
+                    "homepage": "http://robbast.nl"
+                }
+            ],
+            "description": "Semver library that offers utilities, version constraint parsing and validation.",
+            "keywords": [
+                "semantic",
+                "semver",
+                "validation",
+                "versioning"
+            ],
+            "support": {
+                "irc": "irc://irc.freenode.org/composer",
+                "issues": "https://github.com/composer/semver/issues",
+                "source": "https://github.com/composer/semver/tree/3.2.5"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-05-24T12:41:47+00:00"
+        },
+        {
+            "name": "composer/xdebug-handler",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/xdebug-handler.git",
+                "reference": "964adcdd3a28bf9ed5d9ac6450064e0d71ed7496"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/964adcdd3a28bf9ed5d9ac6450064e0d71ed7496",
+                "reference": "964adcdd3a28bf9ed5d9ac6450064e0d71ed7496",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0 || ^8.0",
+                "psr/log": "^1.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^0.12.55",
+                "symfony/phpunit-bridge": "^4.2 || ^5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Composer\\XdebugHandler\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "John Stevenson",
+                    "email": "john-stevenson@blueyonder.co.uk"
+                }
+            ],
+            "description": "Restarts a process without Xdebug.",
+            "keywords": [
+                "Xdebug",
+                "performance"
+            ],
+            "support": {
+                "irc": "irc://irc.freenode.org/composer",
+                "issues": "https://github.com/composer/xdebug-handler/issues",
+                "source": "https://github.com/composer/xdebug-handler/tree/2.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-05-05T19:37:51+00:00"
+        },
+        {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
             "version": "v0.7.1",
             "source": {
@@ -1566,6 +1950,43 @@
             "time": "2020-12-07T18:04:37+00:00"
         },
         {
+            "name": "dnoegel/php-xdg-base-dir",
+            "version": "v0.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dnoegel/php-xdg-base-dir.git",
+                "reference": "8f8a6e48c5ecb0f991c2fdcf5f154a47d85f9ffd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dnoegel/php-xdg-base-dir/zipball/8f8a6e48c5ecb0f991c2fdcf5f154a47d85f9ffd",
+                "reference": "8f8a6e48c5ecb0f991c2fdcf5f154a47d85f9ffd",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~7.0|~6.0|~5.0|~4.8.35"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "XdgBaseDir\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "implementation of xdg base directory specification for php",
+            "support": {
+                "issues": "https://github.com/dnoegel/php-xdg-base-dir/issues",
+                "source": "https://github.com/dnoegel/php-xdg-base-dir/tree/v0.1.1"
+            },
+            "time": "2019-12-04T15:06:13+00:00"
+        },
+        {
             "name": "doctrine/instantiator",
             "version": "1.4.0",
             "source": {
@@ -1633,6 +2054,107 @@
                 }
             ],
             "time": "2020-11-10T18:47:58+00:00"
+        },
+        {
+            "name": "felixfbecker/advanced-json-rpc",
+            "version": "v3.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/felixfbecker/php-advanced-json-rpc.git",
+                "reference": "06f0b06043c7438959dbdeed8bb3f699a19be22e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/felixfbecker/php-advanced-json-rpc/zipball/06f0b06043c7438959dbdeed8bb3f699a19be22e",
+                "reference": "06f0b06043c7438959dbdeed8bb3f699a19be22e",
+                "shasum": ""
+            },
+            "require": {
+                "netresearch/jsonmapper": "^1.0 || ^2.0",
+                "php": "^7.1 || ^8.0",
+                "phpdocumentor/reflection-docblock": "^4.3.4 || ^5.0.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.0 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "AdvancedJsonRpc\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "ISC"
+            ],
+            "authors": [
+                {
+                    "name": "Felix Becker",
+                    "email": "felix.b@outlook.com"
+                }
+            ],
+            "description": "A more advanced JSONRPC implementation",
+            "support": {
+                "issues": "https://github.com/felixfbecker/php-advanced-json-rpc/issues",
+                "source": "https://github.com/felixfbecker/php-advanced-json-rpc/tree/v3.2.0"
+            },
+            "time": "2021-01-10T17:48:47+00:00"
+        },
+        {
+            "name": "felixfbecker/language-server-protocol",
+            "version": "1.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/felixfbecker/php-language-server-protocol.git",
+                "reference": "9d846d1f5cf101deee7a61c8ba7caa0a975cd730"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/felixfbecker/php-language-server-protocol/zipball/9d846d1f5cf101deee7a61c8ba7caa0a975cd730",
+                "reference": "9d846d1f5cf101deee7a61c8ba7caa0a975cd730",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "*",
+                "squizlabs/php_codesniffer": "^3.1",
+                "vimeo/psalm": "^4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "LanguageServerProtocol\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "ISC"
+            ],
+            "authors": [
+                {
+                    "name": "Felix Becker",
+                    "email": "felix.b@outlook.com"
+                }
+            ],
+            "description": "PHP classes for the Language Server Protocol",
+            "keywords": [
+                "language",
+                "microsoft",
+                "php",
+                "server"
+            ],
+            "support": {
+                "issues": "https://github.com/felixfbecker/php-language-server-protocol/issues",
+                "source": "https://github.com/felixfbecker/php-language-server-protocol/tree/1.5.1"
+            },
+            "time": "2021-02-22T14:02:09+00:00"
         },
         {
             "name": "laminas-api-tools/api-tools-hal",
@@ -2069,6 +2591,110 @@
                 }
             ],
             "time": "2020-11-13T09:40:50+00:00"
+        },
+        {
+            "name": "netresearch/jsonmapper",
+            "version": "v2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cweiske/jsonmapper.git",
+                "reference": "e0f1e33a71587aca81be5cffbb9746510e1fe04e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cweiske/jsonmapper/zipball/e0f1e33a71587aca81be5cffbb9746510e1fe04e",
+                "reference": "e0f1e33a71587aca81be5cffbb9746510e1fe04e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-pcre": "*",
+                "ext-reflection": "*",
+                "ext-spl": "*",
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.8.35 || ~5.7 || ~6.4 || ~7.0",
+                "squizlabs/php_codesniffer": "~3.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "JsonMapper": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "OSL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Weiske",
+                    "email": "cweiske@cweiske.de",
+                    "homepage": "http://github.com/cweiske/jsonmapper/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Map nested JSON structures onto PHP classes",
+            "support": {
+                "email": "cweiske@cweiske.de",
+                "issues": "https://github.com/cweiske/jsonmapper/issues",
+                "source": "https://github.com/cweiske/jsonmapper/tree/master"
+            },
+            "time": "2020-04-16T18:48:43+00:00"
+        },
+        {
+            "name": "openlss/lib-array2xml",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nullivex/lib-array2xml.git",
+                "reference": "a91f18a8dfc69ffabe5f9b068bc39bb202c81d90"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nullivex/lib-array2xml/zipball/a91f18a8dfc69ffabe5f9b068bc39bb202c81d90",
+                "reference": "a91f18a8dfc69ffabe5f9b068bc39bb202c81d90",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "LSS": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Bryan Tong",
+                    "email": "bryan@nullivex.com",
+                    "homepage": "https://www.nullivex.com"
+                },
+                {
+                    "name": "Tony Butler",
+                    "email": "spudz76@gmail.com",
+                    "homepage": "https://www.nullivex.com"
+                }
+            ],
+            "description": "Array2XML conversion library credit to lalit.org",
+            "homepage": "https://www.nullivex.com",
+            "keywords": [
+                "array",
+                "array conversion",
+                "xml",
+                "xml conversion"
+            ],
+            "support": {
+                "issues": "https://github.com/nullivex/lib-array2xml/issues",
+                "source": "https://github.com/nullivex/lib-array2xml/tree/master"
+            },
+            "time": "2019-03-29T20:06:56+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -2933,6 +3559,66 @@
             "time": "2021-06-05T04:49:07+00:00"
         },
         {
+            "name": "psalm/plugin-phpunit",
+            "version": "0.16.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/psalm/psalm-plugin-phpunit.git",
+                "reference": "1ce1ef2c3fe8bed6ddaba1607c00b48a52145023"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/psalm/psalm-plugin-phpunit/zipball/1ce1ef2c3fe8bed6ddaba1607c00b48a52145023",
+                "reference": "1ce1ef2c3fe8bed6ddaba1607c00b48a52145023",
+                "shasum": ""
+            },
+            "require": {
+                "composer/package-versions-deprecated": "^1.10",
+                "composer/semver": "^1.4 || ^2.0 || ^3.0",
+                "ext-simplexml": "*",
+                "php": "^7.1 || ^8.0",
+                "vimeo/psalm": "dev-master || dev-4.x || ^4.5"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<7.5"
+            },
+            "require-dev": {
+                "codeception/codeception": "^4.0.3",
+                "php": "^7.3 || ^8.0",
+                "phpunit/phpunit": "^7.5 || ^8.0 || ^9.0",
+                "squizlabs/php_codesniffer": "^3.3.1",
+                "weirdan/codeception-psalm-module": "^0.11.0",
+                "weirdan/prophecy-shim": "^1.0 || ^2.0"
+            },
+            "type": "psalm-plugin",
+            "extra": {
+                "psalm": {
+                    "pluginClass": "Psalm\\PhpUnitPlugin\\Plugin"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psalm\\PhpUnitPlugin\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matt Brown",
+                    "email": "github@muglug.com"
+                }
+            ],
+            "description": "Psalm plugin for PHPUnit",
+            "support": {
+                "issues": "https://github.com/psalm/psalm-plugin-phpunit/issues",
+                "source": "https://github.com/psalm/psalm-plugin-phpunit/tree/0.16.0"
+            },
+            "time": "2021-06-06T07:53:56+00:00"
+        },
+        {
             "name": "psr/link",
             "version": "1.0.0",
             "source": {
@@ -2983,6 +3669,56 @@
                 "source": "https://github.com/php-fig/link/tree/master"
             },
             "time": "2016-10-28T16:06:13+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "1.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "d49695b909c3b7628b6289db5479a1c204601f11"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/d49695b909c3b7628b6289db5479a1c204601f11",
+                "reference": "d49695b909c3b7628b6289db5479a1c204601f11",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "Psr/Log/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/1.1.4"
+            },
+            "time": "2021-05-03T11:20:27+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -4066,6 +4802,171 @@
             "time": "2021-04-09T00:54:41+00:00"
         },
         {
+            "name": "symfony/console",
+            "version": "v5.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/console.git",
+                "reference": "058553870f7809087fa80fa734704a21b9bcaeb2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/console/zipball/058553870f7809087fa80fa734704a21b9bcaeb2",
+                "reference": "058553870f7809087fa80fa734704a21b9bcaeb2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/deprecation-contracts": "^2.1",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/polyfill-php73": "^1.8",
+                "symfony/polyfill-php80": "^1.15",
+                "symfony/service-contracts": "^1.1|^2",
+                "symfony/string": "^5.1"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<4.4",
+                "symfony/dotenv": "<5.1",
+                "symfony/event-dispatcher": "<4.4",
+                "symfony/lock": "<4.4",
+                "symfony/process": "<4.4"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/config": "^4.4|^5.0",
+                "symfony/dependency-injection": "^4.4|^5.0",
+                "symfony/event-dispatcher": "^4.4|^5.0",
+                "symfony/lock": "^4.4|^5.0",
+                "symfony/process": "^4.4|^5.0",
+                "symfony/var-dumper": "^4.4|^5.0"
+            },
+            "suggest": {
+                "psr/log": "For using the console logger",
+                "symfony/event-dispatcher": "",
+                "symfony/lock": "",
+                "symfony/process": ""
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Console\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Eases the creation of beautiful and testable command line interfaces",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "cli",
+                "command line",
+                "console",
+                "terminal"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/console/tree/v5.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-05-26T17:43:10+00:00"
+        },
+        {
+            "name": "symfony/deprecation-contracts",
+            "version": "v2.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "5f38c8804a9e97d23e0c8d63341088cd8a22d627"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/5f38c8804a9e97d23e0c8d63341088cd8a22d627",
+                "reference": "5f38c8804a9e97d23e0c8d63341088cd8a22d627",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.4-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "function.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A generic function and convention to trigger deprecation notices",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-03-23T23:28:01+00:00"
+        },
+        {
             "name": "symfony/polyfill-ctype",
             "version": "v1.23.0",
             "source": {
@@ -4145,6 +5046,575 @@
             "time": "2021-02-19T12:13:01+00:00"
         },
         {
+            "name": "symfony/polyfill-intl-grapheme",
+            "version": "v1.23.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
+                "reference": "24b72c6baa32c746a4d0840147c9715e42bb68ab"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/24b72c6baa32c746a4d0840147c9715e42bb68ab",
+                "reference": "24b72c6baa32c746a4d0840147c9715e42bb68ab",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.23-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Grapheme\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's grapheme_* functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "grapheme",
+                "intl",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.23.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-05-27T09:17:38+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-normalizer",
+            "version": "v1.23.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
+                "reference": "8590a5f561694770bdcd3f9b5c69dde6945028e8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/8590a5f561694770bdcd3f9b5c69dde6945028e8",
+                "reference": "8590a5f561694770bdcd3f9b5c69dde6945028e8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.23-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's Normalizer class and related functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "intl",
+                "normalizer",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.23.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-02-19T12:13:01+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.23.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "2df51500adbaebdc4c38dea4c89a2e131c45c8a1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/2df51500adbaebdc4c38dea4c89a2e131c45c8a1",
+                "reference": "2df51500adbaebdc4c38dea4c89a2e131c45c8a1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.23-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.23.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-05-27T09:27:20+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php73",
+            "version": "v1.23.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php73.git",
+                "reference": "fba8933c384d6476ab14fb7b8526e5287ca7e010"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/fba8933c384d6476ab14fb7b8526e5287ca7e010",
+                "reference": "fba8933c384d6476ab14fb7b8526e5287ca7e010",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.23-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php73\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php73/tree/v1.23.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-02-19T12:13:01+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php80",
+            "version": "v1.23.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php80.git",
+                "reference": "eca0bf41ed421bed1b57c4958bab16aa86b757d0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/eca0bf41ed421bed1b57c4958bab16aa86b757d0",
+                "reference": "eca0bf41ed421bed1b57c4958bab16aa86b757d0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.23-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ion Bazan",
+                    "email": "ion.bazan@gmail.com"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.23.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-02-19T12:13:01+00:00"
+        },
+        {
+            "name": "symfony/service-contracts",
+            "version": "v2.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/service-contracts.git",
+                "reference": "f040a30e04b57fbcc9c6cbcf4dbaa96bd318b9bb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/f040a30e04b57fbcc9c6cbcf4dbaa96bd318b9bb",
+                "reference": "f040a30e04b57fbcc9c6cbcf4dbaa96bd318b9bb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "psr/container": "^1.1"
+            },
+            "suggest": {
+                "symfony/service-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.4-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Service\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to writing services",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/service-contracts/tree/v2.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-04-01T10:43:52+00:00"
+        },
+        {
+            "name": "symfony/string",
+            "version": "v5.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/string.git",
+                "reference": "a9a0f8b6aafc5d2d1c116dcccd1573a95153515b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/string/zipball/a9a0f8b6aafc5d2d1c116dcccd1573a95153515b",
+                "reference": "a9a0f8b6aafc5d2d1c116dcccd1573a95153515b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-intl-grapheme": "~1.0",
+                "symfony/polyfill-intl-normalizer": "~1.0",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/polyfill-php80": "~1.15"
+            },
+            "require-dev": {
+                "symfony/error-handler": "^4.4|^5.0",
+                "symfony/http-client": "^4.4|^5.0",
+                "symfony/translation-contracts": "^1.1|^2",
+                "symfony/var-exporter": "^4.4|^5.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\String\\": ""
+                },
+                "files": [
+                    "Resources/functions.php"
+                ],
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an object-oriented API to strings and deals with bytes, UTF-8 code points and grapheme clusters in a unified way",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "grapheme",
+                "i18n",
+                "string",
+                "unicode",
+                "utf-8",
+                "utf8"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/string/tree/v5.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-05-26T17:43:10+00:00"
+        },
+        {
             "name": "theseer/tokenizer",
             "version": "1.2.0",
             "source": {
@@ -4193,6 +5663,111 @@
                 }
             ],
             "time": "2020-07-12T23:59:07+00:00"
+        },
+        {
+            "name": "vimeo/psalm",
+            "version": "4.7.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/vimeo/psalm.git",
+                "reference": "38c452ae584467e939d55377aaf83b5a26f19dd1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/38c452ae584467e939d55377aaf83b5a26f19dd1",
+                "reference": "38c452ae584467e939d55377aaf83b5a26f19dd1",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^2.4.2",
+                "amphp/byte-stream": "^1.5",
+                "composer/package-versions-deprecated": "^1.8.0",
+                "composer/semver": "^1.4 || ^2.0 || ^3.0",
+                "composer/xdebug-handler": "^1.1 || ^2.0",
+                "dnoegel/php-xdg-base-dir": "^0.1.1",
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "felixfbecker/advanced-json-rpc": "^3.0.3",
+                "felixfbecker/language-server-protocol": "^1.5",
+                "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
+                "nikic/php-parser": "^4.10.5",
+                "openlss/lib-array2xml": "^1.0",
+                "php": "^7.1|^8",
+                "sebastian/diff": "^3.0 || ^4.0",
+                "symfony/console": "^3.4.17 || ^4.1.6 || ^5.0",
+                "webmozart/path-util": "^2.3"
+            },
+            "provide": {
+                "psalm/psalm": "self.version"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.2",
+                "brianium/paratest": "^4.0||^6.0",
+                "ext-curl": "*",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpdocumentor/reflection-docblock": "^5",
+                "phpmyadmin/sql-parser": "5.1.0||dev-master",
+                "phpspec/prophecy": ">=1.9.0",
+                "phpunit/phpunit": "^9.0",
+                "psalm/plugin-phpunit": "^0.13",
+                "slevomat/coding-standard": "^7.0",
+                "squizlabs/php_codesniffer": "^3.5",
+                "symfony/process": "^4.3",
+                "weirdan/phpunit-appveyor-reporter": "^1.0.0",
+                "weirdan/prophecy-shim": "^1.0 || ^2.0"
+            },
+            "suggest": {
+                "ext-igbinary": "^2.0.5"
+            },
+            "bin": [
+                "psalm",
+                "psalm-language-server",
+                "psalm-plugin",
+                "psalm-refactor",
+                "psalter"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.x-dev",
+                    "dev-3.x": "3.x-dev",
+                    "dev-2.x": "2.x-dev",
+                    "dev-1.x": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psalm\\": "src/Psalm/"
+                },
+                "files": [
+                    "src/functions.php",
+                    "src/spl_object_id.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matthew Brown"
+                }
+            ],
+            "description": "A static analysis tool for finding errors in PHP applications",
+            "keywords": [
+                "code",
+                "inspection",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/vimeo/psalm/issues",
+                "source": "https://github.com/vimeo/psalm/tree/4.7.3"
+            },
+            "time": "2021-05-24T04:09:51+00:00"
         },
         {
             "name": "webimpress/coding-standard",
@@ -4306,6 +5881,56 @@
                 "source": "https://github.com/webmozarts/assert/tree/1.10.0"
             },
             "time": "2021-03-09T10:59:23+00:00"
+        },
+        {
+            "name": "webmozart/path-util",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/path-util.git",
+                "reference": "d939f7edc24c9a1bb9c0dee5cb05d8e859490725"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/path-util/zipball/d939f7edc24c9a1bb9c0dee5cb05d8e859490725",
+                "reference": "d939f7edc24c9a1bb9c0dee5cb05d8e859490725",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "webmozart/assert": "~1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6",
+                "sebastian/version": "^1.0.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\PathUtil\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "A robust cross-platform utility for normalizing, comparing and modifying file paths.",
+            "support": {
+                "issues": "https://github.com/webmozart/path-util/issues",
+                "source": "https://github.com/webmozart/path-util/tree/2.3.0"
+            },
+            "time": "2015-12-17T08:42:14+00:00"
         }
     ],
     "aliases": [],

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,0 +1,989 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<files psalm-version="4.7.3@38c452ae584467e939d55377aaf83b5a26f19dd1">
+  <file src="src/AcceptFilterListener.php">
+    <MixedArgument occurrences="3">
+      <code>$headers</code>
+      <code>$headers</code>
+      <code>$whitelistType</code>
+    </MixedArgument>
+    <MixedArrayOffset occurrences="1">
+      <code>$this-&gt;config[$controllerName]</code>
+    </MixedArrayOffset>
+    <MixedAssignment occurrences="3">
+      <code>$controllerName</code>
+      <code>$headers</code>
+      <code>$whitelistType</code>
+    </MixedAssignment>
+    <PossiblyInvalidMethodCall occurrences="1">
+      <code>match</code>
+    </PossiblyInvalidMethodCall>
+    <PossiblyNullReference occurrences="1">
+      <code>getParam</code>
+    </PossiblyNullReference>
+    <UndefinedMethod occurrences="1">
+      <code>match</code>
+    </UndefinedMethod>
+  </file>
+  <file src="src/AcceptListener.php">
+    <InvalidArgument occurrences="1">
+      <code>$controller</code>
+    </InvalidArgument>
+    <MixedArgument occurrences="5">
+      <code>$child</code>
+      <code>$controllerName</code>
+      <code>$criteria</code>
+      <code>$criteria</code>
+      <code>$fallbackConfig</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="6">
+      <code>$child</code>
+      <code>$controllerName</code>
+      <code>$criteria</code>
+      <code>$criteria</code>
+      <code>$criteria</code>
+      <code>$fallbackConfig</code>
+    </MixedAssignment>
+    <MixedInferredReturnType occurrences="1">
+      <code>array|null</code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement occurrences="1">
+      <code>$criteria</code>
+    </MixedReturnStatement>
+    <ParadoxicalCondition occurrences="1">
+      <code>! $criteria || empty($criteria)</code>
+    </ParadoxicalCondition>
+    <PossiblyInvalidArgument occurrences="1">
+      <code>$result-&gt;getVariables()</code>
+    </PossiblyInvalidArgument>
+    <PossiblyNullArgument occurrences="3">
+      <code>$fallbackConfig</code>
+      <code>$fallbackConfig</code>
+      <code>$fallbackConfig</code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference occurrences="1">
+      <code>getParam</code>
+    </PossiblyNullReference>
+    <RedundantConditionGivenDocblockType occurrences="1">
+      <code>is_string($criteria)</code>
+    </RedundantConditionGivenDocblockType>
+  </file>
+  <file src="src/ContentNegotiationOptions.php">
+    <DeprecatedMethod occurrences="3">
+      <code>normalizeKey</code>
+      <code>normalizeKey</code>
+      <code>normalizeKey</code>
+    </DeprecatedMethod>
+    <MixedArgument occurrences="3">
+      <code>$config[$key]</code>
+      <code>$config[$normalizedKey]</code>
+      <code>$key</code>
+    </MixedArgument>
+    <MixedArrayOffset occurrences="4">
+      <code>$config[$key]</code>
+      <code>$config[$key]</code>
+      <code>$mergedConfig[$key]</code>
+      <code>$mergedConfig[$key]</code>
+    </MixedArrayOffset>
+    <MixedAssignment occurrences="3">
+      <code>$key</code>
+      <code>$mergedConfig[$normalizedKey]</code>
+      <code>$mergedConfig[$normalizedKey]</code>
+    </MixedAssignment>
+    <PossiblyInvalidArgument occurrences="1">
+      <code>$options</code>
+    </PossiblyInvalidArgument>
+  </file>
+  <file src="src/ContentTypeFilterListener.php">
+    <MixedArrayOffset occurrences="1">
+      <code>$this-&gt;config[$controllerName]</code>
+    </MixedArrayOffset>
+    <MixedAssignment occurrences="4">
+      <code>$contentTypeHeader</code>
+      <code>$controllerName</code>
+      <code>$headers</code>
+      <code>$matched</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="3">
+      <code>get</code>
+      <code>has</code>
+      <code>match</code>
+    </MixedMethodCall>
+    <PossiblyNullReference occurrences="1">
+      <code>getParam</code>
+    </PossiblyNullReference>
+  </file>
+  <file src="src/ContentTypeListener.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$request</code>
+    </ArgumentTypeCoercion>
+    <InvalidCatch occurrences="1"/>
+    <MissingConstructor occurrences="1">
+      <code>$uploadTmpDir</code>
+    </MissingConstructor>
+    <MixedArgument occurrences="13">
+      <code>$bodyParams</code>
+      <code>$content</code>
+      <code>$content</code>
+      <code>$content</code>
+      <code>$content</code>
+      <code>$contentType</code>
+      <code>$fileInfo['tmp_name']</code>
+      <code>$fileInfo['tmp_name']</code>
+      <code>$fileInfo['tmp_name']</code>
+      <code>$fileInfo['tmp_name']</code>
+      <code>$message</code>
+      <code>$request-&gt;getContent()</code>
+      <code>$request-&gt;getQuery()-&gt;toArray()</code>
+    </MixedArgument>
+    <MixedArrayAccess occurrences="7">
+      <code>$content[0]</code>
+      <code>$data['_embedded']</code>
+      <code>$data['_embedded']</code>
+      <code>$fileInfo['tmp_name']</code>
+      <code>$fileInfo['tmp_name']</code>
+      <code>$fileInfo['tmp_name']</code>
+      <code>$fileInfo['tmp_name']</code>
+    </MixedArrayAccess>
+    <MixedArrayAssignment occurrences="1">
+      <code>$data[$key]</code>
+    </MixedArrayAssignment>
+    <MixedArrayOffset occurrences="1">
+      <code>$data[$key]</code>
+    </MixedArrayOffset>
+    <MixedAssignment occurrences="13">
+      <code>$bodyParams</code>
+      <code>$bodyParams</code>
+      <code>$bodyParams</code>
+      <code>$bodyParams</code>
+      <code>$content</code>
+      <code>$contentType</code>
+      <code>$data</code>
+      <code>$data[$key]</code>
+      <code>$events</code>
+      <code>$fileInfo</code>
+      <code>$key</code>
+      <code>$message</code>
+      <code>$value</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="7">
+      <code>attach</code>
+      <code>count</code>
+      <code>match</code>
+      <code>match</code>
+      <code>match</code>
+      <code>toArray</code>
+      <code>toArray</code>
+    </MixedMethodCall>
+    <PossiblyNullReference occurrences="1">
+      <code>getParams</code>
+    </PossiblyNullReference>
+    <PossiblyUndefinedMethod occurrences="6">
+      <code>getFiles</code>
+      <code>getHeader</code>
+      <code>getMethod</code>
+      <code>getPost</code>
+      <code>getQuery</code>
+      <code>setParam</code>
+    </PossiblyUndefinedMethod>
+    <RedundantCondition occurrences="1">
+      <code>! $bodyParams</code>
+    </RedundantCondition>
+    <TypeDoesNotContainType occurrences="1">
+      <code>$error === JSON_ERROR_NONE &amp;&amp; $isArray</code>
+    </TypeDoesNotContainType>
+    <UndefinedInterfaceMethod occurrences="1">
+      <code>getFiles</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="src/ControllerPlugin/BodyParam.php">
+    <MixedAssignment occurrences="1">
+      <code>$parameterData</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="1">
+      <code>getPost</code>
+    </MixedMethodCall>
+    <PossiblyNullArgument occurrences="1">
+      <code>$param</code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference occurrences="1">
+      <code>getRequest</code>
+    </PossiblyNullReference>
+    <UndefinedInterfaceMethod occurrences="1">
+      <code>getRequest</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="src/ControllerPlugin/BodyParams.php">
+    <MixedAssignment occurrences="1">
+      <code>$parameterData</code>
+    </MixedAssignment>
+    <MixedInferredReturnType occurrences="1">
+      <code>array|ArrayAccess</code>
+    </MixedInferredReturnType>
+    <MixedMethodCall occurrences="1">
+      <code>getPost</code>
+    </MixedMethodCall>
+    <MixedReturnStatement occurrences="1">
+      <code>$controller-&gt;getRequest()-&gt;getPost()</code>
+    </MixedReturnStatement>
+    <PossiblyNullReference occurrences="1">
+      <code>getRequest</code>
+    </PossiblyNullReference>
+    <UndefinedDocblockClass occurrences="1">
+      <code>array|ArrayAccess</code>
+    </UndefinedDocblockClass>
+    <UndefinedInterfaceMethod occurrences="1">
+      <code>getRequest</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="src/ControllerPlugin/QueryParam.php">
+    <MixedAssignment occurrences="1">
+      <code>$parameterData</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="1">
+      <code>getQuery</code>
+    </MixedMethodCall>
+    <PossiblyNullArgument occurrences="1">
+      <code>$param</code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference occurrences="1">
+      <code>getRequest</code>
+    </PossiblyNullReference>
+    <UndefinedInterfaceMethod occurrences="1">
+      <code>getRequest</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="src/ControllerPlugin/QueryParams.php">
+    <MixedAssignment occurrences="1">
+      <code>$parameterData</code>
+    </MixedAssignment>
+    <MixedInferredReturnType occurrences="1">
+      <code>array</code>
+    </MixedInferredReturnType>
+    <MixedMethodCall occurrences="2">
+      <code>getQuery</code>
+      <code>toArray</code>
+    </MixedMethodCall>
+    <MixedReturnStatement occurrences="1">
+      <code>$this-&gt;getController()-&gt;getRequest()-&gt;getQuery()-&gt;toArray()</code>
+    </MixedReturnStatement>
+    <PossiblyNullReference occurrences="1">
+      <code>getRequest</code>
+    </PossiblyNullReference>
+    <UndefinedDocblockClass occurrences="1">
+      <code>RuntimeException</code>
+    </UndefinedDocblockClass>
+    <UndefinedInterfaceMethod occurrences="1">
+      <code>getRequest</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="src/ControllerPlugin/RouteParam.php">
+    <MixedAssignment occurrences="1">
+      <code>$parameterData</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="1">
+      <code>getParam</code>
+    </MixedMethodCall>
+    <PossiblyNullArgument occurrences="1">
+      <code>$param</code>
+    </PossiblyNullArgument>
+    <PossiblyUndefinedMethod occurrences="1">
+      <code>getRouteMatch</code>
+    </PossiblyUndefinedMethod>
+  </file>
+  <file src="src/ControllerPlugin/RouteParams.php">
+    <MixedAssignment occurrences="1">
+      <code>$parameterData</code>
+    </MixedAssignment>
+    <MixedInferredReturnType occurrences="1">
+      <code>array</code>
+    </MixedInferredReturnType>
+    <MixedMethodCall occurrences="1">
+      <code>getParams</code>
+    </MixedMethodCall>
+    <MixedReturnStatement occurrences="1">
+      <code>$controller-&gt;getEvent()-&gt;getRouteMatch()-&gt;getParams()</code>
+    </MixedReturnStatement>
+    <PossiblyUndefinedMethod occurrences="1">
+      <code>getRouteMatch</code>
+    </PossiblyUndefinedMethod>
+  </file>
+  <file src="src/Factory/AcceptFilterListenerFactory.php">
+    <MixedArgument occurrences="1">
+      <code>$options-&gt;getAcceptWhitelist()</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="1">
+      <code>$options</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="1">
+      <code>getAcceptWhitelist</code>
+    </MixedMethodCall>
+  </file>
+  <file src="src/Factory/AcceptListenerFactory.php">
+    <MixedArgument occurrences="1">
+      <code>$container-&gt;get(ContentNegotiationOptions::class)-&gt;toArray()</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="1">
+      <code>$plugins</code>
+    </MixedAssignment>
+    <MixedInferredReturnType occurrences="1">
+      <code>AcceptableViewModelSelector</code>
+    </MixedInferredReturnType>
+    <MixedMethodCall occurrences="3">
+      <code>get</code>
+      <code>has</code>
+      <code>toArray</code>
+    </MixedMethodCall>
+    <MixedReturnStatement occurrences="1">
+      <code>$plugins-&gt;get('AcceptableViewModelSelector')</code>
+    </MixedReturnStatement>
+  </file>
+  <file src="src/Factory/ContentNegotiationOptionsFactory.php">
+    <MixedInferredReturnType occurrences="1">
+      <code>array</code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement occurrences="1">
+      <code>$config['api-tools-content-negotiation']</code>
+    </MixedReturnStatement>
+  </file>
+  <file src="src/Factory/ContentTypeFilterListenerFactory.php">
+    <MixedArgument occurrences="1">
+      <code>$options-&gt;getContentTypeWhitelist()</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="1">
+      <code>$options</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="1">
+      <code>getContentTypeWhitelist</code>
+    </MixedMethodCall>
+  </file>
+  <file src="src/Factory/HttpMethodOverrideListenerFactory.php">
+    <MixedArgument occurrences="1">
+      <code>$httpOverrideMethods</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="2">
+      <code>$httpOverrideMethods</code>
+      <code>$options</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="1">
+      <code>getHttpOverrideMethods</code>
+    </MixedMethodCall>
+  </file>
+  <file src="src/Factory/RenameUploadFilterFactory.php">
+    <DeprecatedInterface occurrences="1">
+      <code>RenameUploadFilterFactory</code>
+    </DeprecatedInterface>
+    <DeprecatedMethod occurrences="1">
+      <code>getServiceLocator</code>
+    </DeprecatedMethod>
+    <MixedArgument occurrences="1">
+      <code>$container-&gt;get('Request')</code>
+    </MixedArgument>
+    <ParamNameMismatch occurrences="1">
+      <code>$container</code>
+    </ParamNameMismatch>
+    <PossiblyNullArgument occurrences="1">
+      <code>$options</code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="src/Factory/UploadFileValidatorFactory.php">
+    <DeprecatedInterface occurrences="1">
+      <code>UploadFileValidatorFactory</code>
+    </DeprecatedInterface>
+    <DeprecatedMethod occurrences="2">
+      <code>getServiceLocator</code>
+      <code>getServiceLocator</code>
+    </DeprecatedMethod>
+    <MixedArgument occurrences="1">
+      <code>$container-&gt;get('Request')</code>
+    </MixedArgument>
+    <ParamNameMismatch occurrences="1">
+      <code>$container</code>
+    </ParamNameMismatch>
+  </file>
+  <file src="src/Filter/RenameUpload.php">
+    <DocblockTypeContradiction occurrences="1">
+      <code>null === $this-&gt;request</code>
+    </DocblockTypeContradiction>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$request</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="src/HttpMethodOverrideListener.php">
+    <MixedArgument occurrences="3">
+      <code>$allowedMethods</code>
+      <code>$overrideMethod</code>
+      <code>$overrideMethod</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="2">
+      <code>$allowedMethods</code>
+      <code>$overrideMethod</code>
+    </MixedAssignment>
+    <PossiblyInvalidMethodCall occurrences="2">
+      <code>getFieldValue</code>
+      <code>has</code>
+    </PossiblyInvalidMethodCall>
+    <PossiblyUndefinedMethod occurrences="2">
+      <code>getFieldValue</code>
+      <code>has</code>
+    </PossiblyUndefinedMethod>
+  </file>
+  <file src="src/JsonModel.php">
+    <DeprecatedClass occurrences="1">
+      <code>array|Traversable|JsonSerializable|StdlibJsonSerializable</code>
+    </DeprecatedClass>
+    <DeprecatedMethod occurrences="1">
+      <code>entity</code>
+    </DeprecatedMethod>
+    <DocblockTypeContradiction occurrences="1">
+      <code>false === $serialized</code>
+    </DocblockTypeContradiction>
+    <ImplementedParamTypeMismatch occurrences="1">
+      <code>$variables</code>
+    </ImplementedParamTypeMismatch>
+    <MixedAssignment occurrences="2">
+      <code>$variables</code>
+      <code>$variables</code>
+    </MixedAssignment>
+    <MixedInferredReturnType occurrences="1">
+      <code>self</code>
+    </MixedInferredReturnType>
+    <ParamNameMismatch occurrences="1">
+      <code>$flag</code>
+    </ParamNameMismatch>
+    <PossiblyUndefinedMethod occurrences="1">
+      <code>$variables</code>
+    </PossiblyUndefinedMethod>
+    <RedundantCondition occurrences="1">
+      <code>method_exists($variables, 'getEntity')</code>
+    </RedundantCondition>
+    <RedundantConditionGivenDocblockType occurrences="1">
+      <code>null !== $this-&gt;jsonpCallback</code>
+    </RedundantConditionGivenDocblockType>
+    <UndefinedDocblockClass occurrences="1">
+      <code>array|Traversable|JsonSerializable|StdlibJsonSerializable</code>
+    </UndefinedDocblockClass>
+  </file>
+  <file src="src/Module.php">
+    <MixedArgument occurrences="2">
+      <code>$services-&gt;get(AcceptListener::class)</code>
+      <code>$services-&gt;get(ContentTypeListener::class)</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="1">
+      <code>$contentNegotiationOptions</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="4">
+      <code>attach</code>
+      <code>attach</code>
+      <code>attach</code>
+      <code>getXHttpMethodOverrideEnabled</code>
+    </MixedMethodCall>
+    <PossiblyNullReference occurrences="1">
+      <code>attach</code>
+    </PossiblyNullReference>
+  </file>
+  <file src="src/MultipartContentParser.php">
+    <MixedArgument occurrences="5">
+      <code>$headers['CONTENT-DISPOSITION']</code>
+      <code>$headers['CONTENT-DISPOSITION']</code>
+      <code>$lastline</code>
+      <code>$lastline</code>
+      <code>$this-&gt;request-&gt;getContent()</code>
+    </MixedArgument>
+    <MixedInferredReturnType occurrences="1">
+      <code>string</code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement occurrences="1">
+      <code>$headers['CONTENT-TYPE']</code>
+    </MixedReturnStatement>
+    <PossiblyFalseArgument occurrences="2">
+      <code>$name</code>
+      <code>$name</code>
+    </PossiblyFalseArgument>
+    <PossiblyInvalidArgument occurrences="5">
+      <code>$tmpFile</code>
+      <code>$tmpFile</code>
+      <code>$tmpFile</code>
+      <code>$tmpFile</code>
+      <code>$tmpFile</code>
+    </PossiblyInvalidArgument>
+    <PossiblyUndefinedArrayOffset occurrences="3">
+      <code>$file['error']</code>
+      <code>$file['tmp_name']</code>
+      <code>$file['tmp_name']</code>
+    </PossiblyUndefinedArrayOffset>
+    <PossiblyUndefinedVariable occurrences="2">
+      <code>$lastline</code>
+      <code>$lastline</code>
+    </PossiblyUndefinedVariable>
+  </file>
+  <file src="src/Request.php">
+    <DocblockTypeContradiction occurrences="2">
+      <code>is_resource($this-&gt;contentStream)</code>
+    </DocblockTypeContradiction>
+    <InvalidPropertyAssignmentValue occurrences="1">
+      <code>fopen('php://temp', 'r+')</code>
+    </InvalidPropertyAssignmentValue>
+    <MixedArgument occurrences="2">
+      <code>$this-&gt;content</code>
+      <code>$this-&gt;contentStream</code>
+    </MixedArgument>
+    <MixedReturnStatement occurrences="1">
+      <code>$this-&gt;contentStream</code>
+    </MixedReturnStatement>
+    <PossiblyInvalidPropertyAssignmentValue occurrences="1">
+      <code>$stream</code>
+    </PossiblyInvalidPropertyAssignmentValue>
+    <PropertyNotSetInConstructor occurrences="6">
+      <code>Request</code>
+      <code>Request</code>
+      <code>Request</code>
+      <code>Request</code>
+      <code>Request</code>
+      <code>Request</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="src/Validator/UploadFile.php">
+    <MixedArgument occurrences="3">
+      <code>$this-&gt;abstractOptions['messages']</code>
+      <code>$value</code>
+      <code>$value</code>
+    </MixedArgument>
+    <MixedArrayAccess occurrences="2">
+      <code>$this-&gt;abstractOptions['messages']</code>
+      <code>$this-&gt;abstractOptions['messages']</code>
+    </MixedArrayAccess>
+    <MixedArrayOffset occurrences="2">
+      <code>$this-&gt;abstractOptions['messages'][static::ATTACK]</code>
+      <code>$this-&gt;abstractOptions['messages'][static::ATTACK]</code>
+    </MixedArrayOffset>
+  </file>
+  <file src="test/AcceptFilterListenerTest.php">
+    <MixedArgument occurrences="2">
+      <code>$this-&gt;listener</code>
+      <code>$this-&gt;listener</code>
+    </MixedArgument>
+    <UndefinedThisPropertyAssignment occurrences="1">
+      <code>$this-&gt;listener</code>
+    </UndefinedThisPropertyAssignment>
+    <UndefinedThisPropertyFetch occurrences="1">
+      <code>$this-&gt;listener</code>
+    </UndefinedThisPropertyFetch>
+  </file>
+  <file src="test/AcceptListenerTest.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$this-&gt;event-&gt;getRequest()</code>
+    </ArgumentTypeCoercion>
+    <InvalidArgument occurrences="1">
+      <code>$selector</code>
+    </InvalidArgument>
+    <MixedArgument occurrences="3">
+      <code>$response-&gt;getApiProblem()-&gt;detail</code>
+      <code>$selector</code>
+      <code>$this-&gt;event</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="3">
+      <code>$listener</code>
+      <code>$listener</code>
+      <code>$selector</code>
+    </MixedAssignment>
+    <MixedFunctionCall occurrences="2">
+      <code>$listener($this-&gt;event)</code>
+      <code>$listener($this-&gt;event)</code>
+    </MixedFunctionCall>
+    <MixedMethodCall occurrences="5">
+      <code>plugin</code>
+      <code>setRequest</code>
+      <code>setResult</code>
+      <code>setResult</code>
+      <code>setResult</code>
+    </MixedMethodCall>
+    <PossiblyInvalidArgument occurrences="1"/>
+    <UndefinedThisPropertyAssignment occurrences="3">
+      <code>$this-&gt;controller</code>
+      <code>$this-&gt;event</code>
+      <code>$this-&gt;listener</code>
+    </UndefinedThisPropertyAssignment>
+    <UndefinedThisPropertyFetch occurrences="6">
+      <code>$this-&gt;controller</code>
+      <code>$this-&gt;event</code>
+      <code>$this-&gt;event</code>
+      <code>$this-&gt;event</code>
+      <code>$this-&gt;listener</code>
+      <code>$this-&gt;listener</code>
+    </UndefinedThisPropertyFetch>
+  </file>
+  <file src="test/ContentTypeFilterListenerTest.php">
+    <MixedArgument occurrences="1">
+      <code>$response-&gt;getApiProblem()-&gt;detail</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="2">
+      <code>$request</code>
+      <code>$request</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="18">
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>getHeaders</code>
+      <code>getHeaders</code>
+      <code>getHeaders</code>
+      <code>getRequest</code>
+      <code>getRequest</code>
+      <code>getRequest</code>
+      <code>onRoute</code>
+      <code>onRoute</code>
+      <code>onRoute</code>
+      <code>onRoute</code>
+      <code>setConfig</code>
+      <code>setConfig</code>
+      <code>setConfig</code>
+      <code>setContent</code>
+      <code>setContent</code>
+    </MixedMethodCall>
+    <PossiblyInvalidArgument occurrences="1"/>
+    <UndefinedThisPropertyAssignment occurrences="2">
+      <code>$this-&gt;event</code>
+      <code>$this-&gt;listener</code>
+    </UndefinedThisPropertyAssignment>
+    <UndefinedThisPropertyFetch occurrences="8">
+      <code>$this-&gt;event</code>
+      <code>$this-&gt;event</code>
+      <code>$this-&gt;event</code>
+      <code>$this-&gt;event</code>
+      <code>$this-&gt;listener</code>
+      <code>$this-&gt;listener</code>
+      <code>$this-&gt;listener</code>
+      <code>$this-&gt;listener</code>
+    </UndefinedThisPropertyFetch>
+  </file>
+  <file src="test/ContentTypeListenerTest.php">
+    <InvalidDocblock occurrences="1">
+      <code>public function multipartFormDataMethods(): array</code>
+    </InvalidDocblock>
+    <MixedArgument occurrences="9">
+      <code>$details['detail']</code>
+      <code>$file['tmp_name']</code>
+      <code>$file['tmp_name']</code>
+      <code>$file['tmp_name']</code>
+      <code>$file['tmp_name']</code>
+      <code>$problem-&gt;detail</code>
+      <code>$problem-&gt;detail</code>
+      <code>$this-&gt;listener</code>
+      <code>$this-&gt;listener</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="31">
+      <code>$files</code>
+      <code>$files</code>
+      <code>$listener</code>
+      <code>$listener</code>
+      <code>$listener</code>
+      <code>$listener</code>
+      <code>$listener</code>
+      <code>$listener</code>
+      <code>$listener</code>
+      <code>$listener</code>
+      <code>$listener</code>
+      <code>$listener</code>
+      <code>$listener</code>
+      <code>$listener</code>
+      <code>$listener</code>
+      <code>$listener</code>
+      <code>$listener</code>
+      <code>$listener</code>
+      <code>$parameterData</code>
+      <code>$parameterData</code>
+      <code>$parameterData</code>
+      <code>$params</code>
+      <code>$params</code>
+      <code>$params</code>
+      <code>$params</code>
+      <code>$params</code>
+      <code>$params</code>
+      <code>$params</code>
+      <code>$params</code>
+      <code>$params</code>
+      <code>$params</code>
+    </MixedAssignment>
+    <MixedFunctionCall occurrences="16">
+      <code>$listener($event)</code>
+      <code>$listener($event)</code>
+      <code>$listener($event)</code>
+      <code>$listener($event)</code>
+      <code>$listener($event)</code>
+      <code>$listener($event)</code>
+      <code>$listener($event)</code>
+      <code>$listener($event)</code>
+      <code>$listener($event)</code>
+      <code>$listener($event)</code>
+      <code>$listener($event)</code>
+      <code>$listener($event)</code>
+      <code>$listener($event)</code>
+      <code>$listener($event)</code>
+      <code>$listener($event)</code>
+      <code>$listener($event)</code>
+    </MixedFunctionCall>
+    <MixedInferredReturnType occurrences="1">
+      <code>array</code>
+    </MixedInferredReturnType>
+    <MixedMethodCall occurrences="17">
+      <code>count</code>
+      <code>count</code>
+      <code>get</code>
+      <code>get</code>
+      <code>getBodyParams</code>
+      <code>getBodyParams</code>
+      <code>getBodyParams</code>
+      <code>getBodyParams</code>
+      <code>getBodyParams</code>
+      <code>getBodyParams</code>
+      <code>getBodyParams</code>
+      <code>getBodyParams</code>
+      <code>getBodyParams</code>
+      <code>getBodyParams</code>
+      <code>onFinish</code>
+      <code>onFinish</code>
+      <code>onFinish</code>
+    </MixedMethodCall>
+    <PossiblyInvalidArgument occurrences="16">
+      <code>$this-&gt;createRouteMatch([])</code>
+      <code>$this-&gt;createRouteMatch([])</code>
+      <code>$this-&gt;createRouteMatch([])</code>
+      <code>$this-&gt;createRouteMatch([])</code>
+      <code>$this-&gt;createRouteMatch([])</code>
+      <code>$this-&gt;createRouteMatch([])</code>
+      <code>$this-&gt;createRouteMatch([])</code>
+      <code>$this-&gt;createRouteMatch([])</code>
+      <code>$this-&gt;createRouteMatch([])</code>
+      <code>$this-&gt;createRouteMatch([])</code>
+      <code>$this-&gt;createRouteMatch([])</code>
+      <code>$this-&gt;createRouteMatch([])</code>
+      <code>$this-&gt;createRouteMatch([])</code>
+      <code>$this-&gt;createRouteMatch([])</code>
+      <code>$this-&gt;createRouteMatch([])</code>
+      <code>$this-&gt;createRouteMatch([])</code>
+    </PossiblyInvalidArgument>
+    <PossiblyInvalidMethodCall occurrences="14">
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+    </PossiblyInvalidMethodCall>
+    <PossiblyUndefinedMethod occurrences="14">
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+    </PossiblyUndefinedMethod>
+    <UndefinedThisPropertyAssignment occurrences="1">
+      <code>$this-&gt;listener</code>
+    </UndefinedThisPropertyAssignment>
+    <UndefinedThisPropertyFetch occurrences="19">
+      <code>$this-&gt;listener</code>
+      <code>$this-&gt;listener</code>
+      <code>$this-&gt;listener</code>
+      <code>$this-&gt;listener</code>
+      <code>$this-&gt;listener</code>
+      <code>$this-&gt;listener</code>
+      <code>$this-&gt;listener</code>
+      <code>$this-&gt;listener</code>
+      <code>$this-&gt;listener</code>
+      <code>$this-&gt;listener</code>
+      <code>$this-&gt;listener</code>
+      <code>$this-&gt;listener</code>
+      <code>$this-&gt;listener</code>
+      <code>$this-&gt;listener</code>
+      <code>$this-&gt;listener</code>
+      <code>$this-&gt;listener</code>
+      <code>$this-&gt;listener</code>
+      <code>$this-&gt;listener</code>
+      <code>$this-&gt;listener</code>
+    </UndefinedThisPropertyFetch>
+  </file>
+  <file src="test/Factory/AcceptFilterListenerFactoryTest.php">
+    <TooManyArguments occurrences="1">
+      <code>$factory</code>
+    </TooManyArguments>
+  </file>
+  <file src="test/Factory/AcceptListenerFactoryTest.php">
+    <TooManyArguments occurrences="1">
+      <code>$factory</code>
+    </TooManyArguments>
+  </file>
+  <file src="test/Factory/ContentNegotiationOptionsFactoryTest.php">
+    <TooManyArguments occurrences="3">
+      <code>$factory</code>
+      <code>$factory</code>
+      <code>$factory</code>
+    </TooManyArguments>
+  </file>
+  <file src="test/Factory/ContentTypeFilterListenerFactoryTest.php">
+    <TooManyArguments occurrences="1">
+      <code>$factory</code>
+    </TooManyArguments>
+  </file>
+  <file src="test/Factory/HttpMethodOverrideListenerFactoryTest.php">
+    <MixedArgument occurrences="1">
+      <code>$container-&gt;reveal()</code>
+    </MixedArgument>
+    <MixedMethodCall occurrences="1">
+      <code>willReturn</code>
+    </MixedMethodCall>
+    <PossiblyInvalidMethodCall occurrences="1">
+      <code>willReturn</code>
+    </PossiblyInvalidMethodCall>
+    <PossiblyUndefinedMethod occurrences="1">
+      <code>reveal</code>
+    </PossiblyUndefinedMethod>
+    <TooManyArguments occurrences="1">
+      <code>$factory</code>
+    </TooManyArguments>
+  </file>
+  <file src="test/Factory/RenameUploadFilterFactoryTest.php">
+    <MixedAssignment occurrences="2">
+      <code>$filter</code>
+      <code>$otherFilter</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="2">
+      <code>getTarget</code>
+      <code>getTarget</code>
+    </MixedMethodCall>
+  </file>
+  <file src="test/Filter/RenameUploadTest.php">
+    <InvalidScalarArgument occurrences="1">
+      <code>$file['tmp_name']</code>
+    </InvalidScalarArgument>
+    <MixedArgument occurrences="7">
+      <code>$this-&gt;targetDir</code>
+      <code>$this-&gt;targetDir</code>
+      <code>$this-&gt;tmpDir</code>
+      <code>$this-&gt;tmpDir</code>
+      <code>$this-&gt;uploadDir</code>
+      <code>$this-&gt;uploadDir</code>
+      <code>$this-&gt;uploadDir</code>
+    </MixedArgument>
+    <MixedOperand occurrences="1">
+      <code>$this-&gt;targetDir</code>
+    </MixedOperand>
+    <UndefinedDocblockClass occurrences="1">
+      <code>$filter-&gt;filter($file)</code>
+    </UndefinedDocblockClass>
+    <UndefinedThisPropertyAssignment occurrences="3">
+      <code>$this-&gt;targetDir</code>
+      <code>$this-&gt;tmpDir</code>
+      <code>$this-&gt;uploadDir</code>
+    </UndefinedThisPropertyAssignment>
+    <UndefinedThisPropertyFetch occurrences="5">
+      <code>$this-&gt;targetDir</code>
+      <code>$this-&gt;targetDir</code>
+      <code>$this-&gt;tmpDir</code>
+      <code>$this-&gt;uploadDir</code>
+      <code>$this-&gt;uploadDir</code>
+    </UndefinedThisPropertyFetch>
+  </file>
+  <file src="test/HttpMethodOverrideListenerTest.php">
+    <InvalidArgument occurrences="1">
+      <code>testHttpMethodOverrideListener</code>
+    </InvalidArgument>
+    <MixedArgument occurrences="2">
+      <code>$problem-&gt;detail</code>
+      <code>$problem-&gt;detail</code>
+    </MixedArgument>
+    <PossiblyInvalidArgument occurrences="1">
+      <code>$this-&gt;createRouteMatch([])</code>
+    </PossiblyInvalidArgument>
+    <PossiblyInvalidMethodCall occurrences="3">
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+    </PossiblyInvalidMethodCall>
+    <PossiblyUndefinedMethod occurrences="3">
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+    </PossiblyUndefinedMethod>
+  </file>
+  <file src="test/JsonModelTest.php">
+    <InvalidArgument occurrences="1">
+      <code>new TestAsset\ModelWithJson()</code>
+    </InvalidArgument>
+    <MixedAssignment occurrences="2">
+      <code>$data</code>
+      <code>$data</code>
+    </MixedAssignment>
+  </file>
+  <file src="test/RequestTest.php">
+    <MixedArgument occurrences="6">
+      <code>$stream</code>
+      <code>$this-&gt;request</code>
+      <code>$this-&gt;request</code>
+      <code>$this-&gt;request</code>
+      <code>$this-&gt;request</code>
+      <code>$this-&gt;request</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="1">
+      <code>$stream</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="4">
+      <code>getContentAsStream</code>
+      <code>getContentAsStream</code>
+      <code>setContentStream</code>
+      <code>setContentStream</code>
+    </MixedMethodCall>
+    <UndefinedThisPropertyAssignment occurrences="1">
+      <code>$this-&gt;request</code>
+    </UndefinedThisPropertyAssignment>
+    <UndefinedThisPropertyFetch occurrences="7">
+      <code>$this-&gt;request</code>
+      <code>$this-&gt;request</code>
+      <code>$this-&gt;request</code>
+      <code>$this-&gt;request</code>
+      <code>$this-&gt;request</code>
+      <code>$this-&gt;request</code>
+      <code>$this-&gt;request</code>
+    </UndefinedThisPropertyFetch>
+  </file>
+  <file src="test/RouteMatchFactoryTrait.php">
+    <UndefinedDocblockClass occurrences="1">
+      <code>V2RouteMatch|RouteMatch</code>
+    </UndefinedDocblockClass>
+  </file>
+  <file src="test/Validator/UploadFileTest.php">
+    <InvalidScalarArgument occurrences="1">
+      <code>1</code>
+    </InvalidScalarArgument>
+    <MixedMethodCall occurrences="3">
+      <code>getMessages</code>
+      <code>isValid</code>
+      <code>setRequest</code>
+    </MixedMethodCall>
+    <PossiblyNullArgument occurrences="1">
+      <code>var_export($this-&gt;validator-&gt;getMessages(), 1)</code>
+    </PossiblyNullArgument>
+    <UndefinedThisPropertyAssignment occurrences="1">
+      <code>$this-&gt;validator</code>
+    </UndefinedThisPropertyAssignment>
+    <UndefinedThisPropertyFetch occurrences="1">
+      <code>$this-&gt;validator</code>
+    </UndefinedThisPropertyFetch>
+  </file>
+</files>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<psalm
+    totallyTyped="true"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    errorBaseline="psalm-baseline.xml"
+>
+    <projectFiles>
+        <directory name="config"/>
+        <directory name="src"/>
+        <directory name="test"/>
+        <ignoreFiles>
+            <directory name="test/TestAsset"/>
+            <directory name="vendor"/>
+        </ignoreFiles>
+    </projectFiles>
+
+    <issueHandlers>
+        <InternalMethod>
+            <errorLevel type="suppress">
+                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::method"/>
+            </errorLevel>
+            <errorLevel type="suppress">
+                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::willReturn"/>
+            </errorLevel>
+            <errorLevel type="suppress">
+                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::with"/>
+            </errorLevel>
+        </InternalMethod>
+    </issueHandlers>
+
+    <plugins>
+        <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>
+    </plugins>
+</psalm>

--- a/src/AcceptListener.php
+++ b/src/AcceptListener.php
@@ -144,7 +144,8 @@ class AcceptListener
      *
      * If the result is an array, we pass those values as the view model variables.
      *
-     * @param  array|ViewModel $result
+     * @param array|ViewModel $result
+     * @return void
      */
     protected function populateViewModel($result, ViewModelInterface $viewModel, MvcEvent $e)
     {

--- a/src/ContentNegotiationOptions.php
+++ b/src/ContentNegotiationOptions.php
@@ -141,6 +141,7 @@ class ContentNegotiationOptions extends AbstractOptions
 
     /**
      * @param array $controllers
+     * @return void
      */
     public function setControllers(array $controllers)
     {
@@ -157,6 +158,7 @@ class ContentNegotiationOptions extends AbstractOptions
 
     /**
      * @param array $selectors
+     * @return void
      */
     public function setSelectors(array $selectors)
     {
@@ -173,6 +175,7 @@ class ContentNegotiationOptions extends AbstractOptions
 
     /**
      * @param array $whitelist
+     * @return void
      */
     public function setAcceptWhitelist(array $whitelist)
     {
@@ -189,6 +192,7 @@ class ContentNegotiationOptions extends AbstractOptions
 
     /**
      * @param array $whitelist
+     * @return void
      */
     public function setContentTypeWhitelist(array $whitelist)
     {
@@ -205,6 +209,7 @@ class ContentNegotiationOptions extends AbstractOptions
 
     /**
      * @param boolean $xHttpMethodOverrideEnabled
+     * @return void
      */
     public function setXHttpMethodOverrideEnabled($xHttpMethodOverrideEnabled)
     {
@@ -221,6 +226,7 @@ class ContentNegotiationOptions extends AbstractOptions
 
     /**
      * @param array $httpOverrideMethods
+     * @return void
      */
     public function setHttpOverrideMethods(array $httpOverrideMethods)
     {

--- a/src/ContentTypeListener.php
+++ b/src/ContentTypeListener.php
@@ -141,6 +141,8 @@ class ContentTypeListener
 
     /**
      * Remove upload files if still present in filesystem
+     *
+     * @return void
      */
     public function onFinish(MvcEvent $e)
     {
@@ -215,6 +217,7 @@ class ContentTypeListener
      * Attach the file cleanup listener
      *
      * @param string $uploadTmpDir Directory in which file uploads were made
+     * @return void
      */
     protected function attachFileCleanupListener(MvcEvent $event, $uploadTmpDir)
     {

--- a/src/Factory/RenameUploadFilterFactory.php
+++ b/src/Factory/RenameUploadFilterFactory.php
@@ -55,6 +55,7 @@ class RenameUploadFilterFactory implements FactoryInterface
      * Allow injecting options at build time; required for v2 compatibility.
      *
      * @param array $options
+     * @return void
      */
     public function setCreationOptions(array $options)
     {

--- a/src/Factory/UploadFileValidatorFactory.php
+++ b/src/Factory/UploadFileValidatorFactory.php
@@ -62,6 +62,7 @@ class UploadFileValidatorFactory implements FactoryInterface
      * Allow injecting options at build time; required for v2 compatibility.
      *
      * @param array $options
+     * @return void
      */
     public function setCreationOptions(array $options)
     {

--- a/src/Filter/RenameUpload.php
+++ b/src/Filter/RenameUpload.php
@@ -16,6 +16,7 @@ class RenameUpload extends BaseFilter
     /** @var RequestInterface */
     protected $request;
 
+    /** @return void */
     public function setRequest(RequestInterface $request)
     {
         $this->request = $request;

--- a/src/JsonModel.php
+++ b/src/JsonModel.php
@@ -112,6 +112,7 @@ class JsonModel extends BaseJsonModel
      * Determine if an error needs to be raised; if so, throw an exception
      *
      * @param int $error One of the JSON_ERROR_* constants
+     * @return never
      * @throws Exception\InvalidJsonException
      */
     protected function raiseError($error)

--- a/src/Validator/UploadFile.php
+++ b/src/Validator/UploadFile.php
@@ -13,6 +13,7 @@ class UploadFile extends BaseValidator
     /** @var null|RequestInterface */
     protected $request;
 
+    /** @return void */
     public function setRequest(RequestInterface $request)
     {
         $this->request = $request;

--- a/test/AcceptFilterListenerTest.php
+++ b/test/AcceptFilterListenerTest.php
@@ -20,7 +20,7 @@ class AcceptFilterListenerTest extends TestCase
     /**
      * @group 58
      */
-    public function testMissingAcceptHeaderIndicatesValidMediaType()
+    public function testMissingAcceptHeaderIndicatesValidMediaType(): void
     {
         $headers = $this->prophesize(Headers::class);
         $headers->has('accept')->willReturn(false);

--- a/test/AcceptListenerTest.php
+++ b/test/AcceptListenerTest.php
@@ -49,7 +49,7 @@ class AcceptListenerTest extends TestCase
         $this->controller->setPluginManager($plugins);
     }
 
-    public function testInabilityToResolveViewModelReturnsApiProblemResponse()
+    public function testInabilityToResolveViewModelReturnsApiProblemResponse(): void
     {
         $listener = $this->listener;
         $this->event->setResult(['foo' => 'bar']);
@@ -60,7 +60,7 @@ class AcceptListenerTest extends TestCase
         $this->assertStringContainsString('Unable to resolve', $response->getApiProblem()->detail);
     }
 
-    public function testReturnADefaultViewModelIfNoCriteriaSpecifiedForAController()
+    public function testReturnADefaultViewModelIfNoCriteriaSpecifiedForAController(): void
     {
         $selector = $this->controller->plugin('AcceptableViewModelSelector');
         $listener = new AcceptListener($selector, []);
@@ -74,7 +74,7 @@ class AcceptListenerTest extends TestCase
     /**
      * @group 22
      */
-    public function testShouldExitEarlyIfNonHttpRequestPresentInEvent()
+    public function testShouldExitEarlyIfNonHttpRequestPresentInEvent(): void
     {
         $request = $this->getMockBuilder(RequestInterface::class)->getMock();
         $this->event->setRequest($request);

--- a/test/ContentNegotiationOptionsTest.php
+++ b/test/ContentNegotiationOptionsTest.php
@@ -21,7 +21,7 @@ class ContentNegotiationOptionsTest extends TestCase
     /**
      * @dataProvider dashSeparatedOptions
      */
-    public function testSetNormalizesDashSeparatedKeysToUnderscoreSeparated(string $key, string $normalized)
+    public function testSetNormalizesDashSeparatedKeysToUnderscoreSeparated(string $key, string $normalized): void
     {
         $options         = new ContentNegotiationOptions();
         $options->{$key} = ['value'];
@@ -32,7 +32,7 @@ class ContentNegotiationOptionsTest extends TestCase
     /**
      * @dataProvider dashSeparatedOptions
      */
-    public function testConstructorAllowsDashSeparatedKeys(string $key, string $normalized)
+    public function testConstructorAllowsDashSeparatedKeys(string $key, string $normalized): void
     {
         $options = new ContentNegotiationOptions([$key => ['value']]);
         $this->assertEquals(['value'], $options->{$key});
@@ -42,7 +42,7 @@ class ContentNegotiationOptionsTest extends TestCase
     /**
      * @dataProvider dashSeparatedOptions
      */
-    public function testDashAndUnderscoreSeparatedValuesGetMerged(string $key, string $normalized)
+    public function testDashAndUnderscoreSeparatedValuesGetMerged(string $key, string $normalized): void
     {
         $keyValue        = 'valueKey';
         $normalizedValue = 'valueNormalized';

--- a/test/ContentTypeFilterListenerTest.php
+++ b/test/ContentTypeFilterListenerTest.php
@@ -24,12 +24,12 @@ class ContentTypeFilterListenerTest extends TestCase
         ]));
     }
 
-    public function testListenerDoesNothingIfNoConfigurationExistsForController()
+    public function testListenerDoesNothingIfNoConfigurationExistsForController(): void
     {
         $this->assertNull($this->listener->onRoute($this->event));
     }
 
-    public function testListenerDoesNothingIfRequestContentTypeIsInControllerWhitelist()
+    public function testListenerDoesNothingIfRequestContentTypeIsInControllerWhitelist(): void
     {
         $contentType = 'application/vnd.laminas.v1.foo+json';
         $this->listener->setConfig([
@@ -41,7 +41,7 @@ class ContentTypeFilterListenerTest extends TestCase
         $this->assertNull($this->listener->onRoute($this->event));
     }
 
-    public function testListenerReturnsApiProblemResponseIfRequestContentTypeIsNotInControllerWhitelist()
+    public function testListenerReturnsApiProblemResponseIfRequestContentTypeIsNotInControllerWhitelist(): void
     {
         $contentType = 'application/vnd.laminas.v1.foo+json';
         $this->listener->setConfig([
@@ -61,7 +61,7 @@ class ContentTypeFilterListenerTest extends TestCase
     /**
      * @group 66
      */
-    public function testCastsObjectBodyContentToStringBeforeWorkingWithIt()
+    public function testCastsObjectBodyContentToStringBeforeWorkingWithIt(): void
     {
         $contentType = 'application/vnd.laminas.v1.foo+json';
         $this->listener->setConfig([

--- a/test/ContentTypeListenerTest.php
+++ b/test/ContentTypeListenerTest.php
@@ -57,7 +57,7 @@ class ContentTypeListenerTest extends TestCase
      * @group 3
      * @dataProvider methodsWithBodies
      */
-    public function testJsonDecodeErrorsReturnsProblemResponse(string $method)
+    public function testJsonDecodeErrorsReturnsProblemResponse(string $method): void
     {
         $listener = $this->listener;
 
@@ -81,7 +81,7 @@ class ContentTypeListenerTest extends TestCase
      * @group 3
      * @dataProvider methodsWithBodies
      */
-    public function testJsonDecodeStringErrorsReturnsProblemResponse(string $method)
+    public function testJsonDecodeStringErrorsReturnsProblemResponse(string $method): void
     {
         $listener = $this->listener;
 
@@ -114,7 +114,7 @@ class ContentTypeListenerTest extends TestCase
     /**
      * @dataProvider multipartFormDataMethods
      */
-    public function testCanDecodeMultipartFormDataRequestsForPutPatchAndDeleteOperations(string $method)
+    public function testCanDecodeMultipartFormDataRequestsForPutPatchAndDeleteOperations(string $method): void
     {
         $request = new Request();
         $request->setMethod($method);
@@ -129,7 +129,7 @@ class ContentTypeListenerTest extends TestCase
         $event->setRouteMatch($this->createRouteMatch([]));
 
         $listener = $this->listener;
-        $result   = $listener($event);
+        $listener($event);
 
         $parameterData = $event->getParam('LaminasContentNegotiationParameterData');
         $params        = $parameterData->getBodyParams();
@@ -154,7 +154,7 @@ class ContentTypeListenerTest extends TestCase
     /**
      * @dataProvider multipartFormDataMethods
      */
-    public function testCanDecodeMultipartFormDataRequestsFromStreamsForPutAndPatchOperations(string $method)
+    public function testCanDecodeMultipartFormDataRequestsFromStreamsForPutAndPatchOperations(string $method): void
     {
         $request = new ContentNegotiationRequest();
         $request->setMethod($method);
@@ -169,7 +169,7 @@ class ContentTypeListenerTest extends TestCase
         $event->setRouteMatch($this->createRouteMatch([]));
 
         $listener = $this->listener;
-        $result   = $listener($event);
+        $listener($event);
 
         $parameterData = $event->getParam('LaminasContentNegotiationParameterData');
         $params        = $parameterData->getBodyParams();
@@ -191,7 +191,7 @@ class ContentTypeListenerTest extends TestCase
         $this->assertTrue(file_exists($file['tmp_name']));
     }
 
-    public function testDecodingMultipartFormDataWithFileRegistersFileCleanupEventListener()
+    public function testDecodingMultipartFormDataWithFileRegistersFileCleanupEventListener(): void
     {
         $request = new Request();
         $request->setMethod('PATCH');
@@ -218,10 +218,10 @@ class ContentTypeListenerTest extends TestCase
         $event->setRouteMatch($this->createRouteMatch([]));
 
         $listener = $this->listener;
-        $result   = $listener($event);
+        $listener($event);
     }
 
-    public function testOnFinishWillRemoveAnyUploadFilesUploadedByTheListener()
+    public function testOnFinishWillRemoveAnyUploadFilesUploadedByTheListener(): void
     {
         $tmpDir  = MultipartContentParser::getUploadTempDir();
         $tmpFile = tempnam($tmpDir, 'laminasc');
@@ -255,7 +255,7 @@ class ContentTypeListenerTest extends TestCase
         $this->assertFileDoesNotExist($tmpFile);
     }
 
-    public function testOnFinishDoesNotRemoveUploadFilesTheListenerDidNotCreate()
+    public function testOnFinishDoesNotRemoveUploadFilesTheListenerDidNotCreate(): void
     {
         $tmpDir  = MultipartContentParser::getUploadTempDir();
         $tmpFile = tempnam($tmpDir, 'php');
@@ -281,7 +281,7 @@ class ContentTypeListenerTest extends TestCase
         unlink($tmpFile);
     }
 
-    public function testOnFinishDoesNotRemoveUploadFilesThatHaveBeenMoved()
+    public function testOnFinishDoesNotRemoveUploadFilesThatHaveBeenMoved(): void
     {
         $tmpDir = sys_get_temp_dir() . '/' . str_replace('\\', '_', self::class);
         mkdir($tmpDir);
@@ -311,7 +311,7 @@ class ContentTypeListenerTest extends TestCase
      * @group 35
      * @dataProvider methodsWithBodies
      */
-    public function testWillNotAttemptToInjectNullValueForBodyParams(string $method)
+    public function testWillNotAttemptToInjectNullValueForBodyParams(string $method): void
     {
         $listener = $this->listener;
 
@@ -357,7 +357,7 @@ class ContentTypeListenerTest extends TestCase
     public function testWillNotAttemptToInjectNullValueForBodyParamsWhenContentIsWhitespace(
         string $method,
         string $content
-    ) {
+    ): void {
         $listener = $this->listener;
 
         $request = new Request();
@@ -399,7 +399,7 @@ class ContentTypeListenerTest extends TestCase
      * @group 36
      * @dataProvider methodsWithLeadingWhitespace
      */
-    public function testWillHandleJsonContentWithLeadingWhitespace(string $method, string $content)
+    public function testWillHandleJsonContentWithLeadingWhitespace(string $method, string $content): void
     {
         $listener = $this->listener;
 
@@ -442,7 +442,7 @@ class ContentTypeListenerTest extends TestCase
      * @group 36
      * @dataProvider methodsWithTrailingWhitespace
      */
-    public function testWillHandleJsonContentWithTrailingWhitespace(string $method, string $content)
+    public function testWillHandleJsonContentWithTrailingWhitespace(string $method, string $content): void
     {
         $listener = $this->listener;
 
@@ -485,7 +485,7 @@ class ContentTypeListenerTest extends TestCase
      * @group 36
      * @dataProvider methodsWithLeadingAndTrailingWhitespace
      */
-    public function testWillHandleJsonContentWithLeadingAndTrailingWhitespace(string $method, string $content)
+    public function testWillHandleJsonContentWithLeadingAndTrailingWhitespace(string $method, string $content): void
     {
         $listener = $this->listener;
 
@@ -519,7 +519,7 @@ class ContentTypeListenerTest extends TestCase
      * @param mixed $content
      * @dataProvider methodsWithWhitespaceInsideBody
      */
-    public function testWillNotRemoveWhitespaceInsideBody(string $method, string $content)
+    public function testWillNotRemoveWhitespaceInsideBody(string $method, string $content): void
     {
         $listener = $this->listener;
 
@@ -541,7 +541,7 @@ class ContentTypeListenerTest extends TestCase
     /**
      * @group 42
      */
-    public function testReturns400ResponseWhenBodyPartIsMissingName()
+    public function testReturns400ResponseWhenBodyPartIsMissingName(): void
     {
         $request = new Request();
         $request->setMethod('PUT');
@@ -564,7 +564,7 @@ class ContentTypeListenerTest extends TestCase
         $this->assertStringContainsString('does not contain a "name" field', $details['detail']);
     }
 
-    public function testReturnsArrayWhenFieldNamesHaveArraySyntax()
+    public function testReturnsArrayWhenFieldNamesHaveArraySyntax(): void
     {
         $request = new Request();
         $request->setMethod('PUT');
@@ -576,8 +576,8 @@ class ContentTypeListenerTest extends TestCase
         $event = new MvcEvent();
         $event->setRequest($request);
         $event->setRouteMatch($this->createRouteMatch([]));
-        $listener      = $this->listener;
-        $result        = $listener($event);
+        $listener = $this->listener;
+        $listener($event);
         $parameterData = $event->getParam('LaminasContentNegotiationParameterData');
         $params        = $parameterData->getBodyParams();
         $this->assertEquals([
@@ -598,7 +598,7 @@ class ContentTypeListenerTest extends TestCase
      * @group 50
      * @dataProvider methodsWithBodies
      */
-    public function testMergesHalEmbeddedPropertiesIntoTopLevelObjectWhenDecodingHalJson(string $method)
+    public function testMergesHalEmbeddedPropertiesIntoTopLevelObjectWhenDecodingHalJson(string $method): void
     {
         $data = [
             'foo'       => 'bar',
@@ -655,7 +655,7 @@ class ContentTypeListenerTest extends TestCase
      * @dataProvider methodsWithStringContent
      * @param string|int $key
      */
-    public function testStringContentIsParsedCorrectlyToAnArray(string $method, string $data, $key)
+    public function testStringContentIsParsedCorrectlyToAnArray(string $method, string $data, $key): void
     {
         $listener = $this->listener;
 

--- a/test/Factory/AcceptFilterListenerFactoryTest.php
+++ b/test/Factory/AcceptFilterListenerFactoryTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 
 class AcceptFilterListenerFactoryTest extends TestCase
 {
-    public function testCreateServiceShouldReturnAcceptFilterListenerInstance()
+    public function testCreateServiceShouldReturnAcceptFilterListenerInstance(): void
     {
         $serviceManager = new ServiceManager();
         $serviceManager->setService(

--- a/test/Factory/AcceptListenerFactoryTest.php
+++ b/test/Factory/AcceptListenerFactoryTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 
 class AcceptListenerFactoryTest extends TestCase
 {
-    public function testCreateServiceShouldReturnAcceptListenerInstance()
+    public function testCreateServiceShouldReturnAcceptListenerInstance(): void
     {
         $serviceManager = new ServiceManager();
         $serviceManager->setService(

--- a/test/Factory/ContentNegotiationOptionsFactoryTest.php
+++ b/test/Factory/ContentNegotiationOptionsFactoryTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 class ContentNegotiationOptionsFactoryTest extends TestCase
 {
-    public function testCreateServiceShouldReturnContentNegotiationOptionsInstance()
+    public function testCreateServiceShouldReturnContentNegotiationOptionsInstance(): void
     {
         $config = [
             'api-tools-content-negotiation' => [
@@ -27,7 +27,7 @@ class ContentNegotiationOptionsFactoryTest extends TestCase
         $this->assertInstanceOf(ContentNegotiationOptions::class, $service);
     }
 
-    public function testCreateServiceShouldReturnContentNegotiationOptionsInstanceWithOptions()
+    public function testCreateServiceShouldReturnContentNegotiationOptionsInstanceWithOptions(): void
     {
         $config = [
             'api-tools-content-negotiation' => [
@@ -45,7 +45,7 @@ class ContentNegotiationOptionsFactoryTest extends TestCase
         $this->assertNotEmpty($service->toArray());
     }
 
-    public function testCreateServiceWithoutConfigShouldReturnContentNegotiationOptionsInstance()
+    public function testCreateServiceWithoutConfigShouldReturnContentNegotiationOptionsInstance(): void
     {
         $serviceManager = new ServiceManager();
 

--- a/test/Factory/ContentTypeFilterListenerFactoryTest.php
+++ b/test/Factory/ContentTypeFilterListenerFactoryTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 
 class ContentTypeFilterListenerFactoryTest extends TestCase
 {
-    public function testCreateServiceShouldReturnContentTypeFilterListenerInstance()
+    public function testCreateServiceShouldReturnContentTypeFilterListenerInstance(): void
     {
         $serviceManager = new ServiceManager();
         $serviceManager->setService(

--- a/test/Factory/HttpMethodOverrideListenerFactoryTest.php
+++ b/test/Factory/HttpMethodOverrideListenerFactoryTest.php
@@ -14,7 +14,7 @@ class HttpMethodOverrideListenerFactoryTest extends TestCase
 {
     use ProphecyTrait;
 
-    public function testCreateServiceShouldReturnContentTypeFilterListenerInstance()
+    public function testCreateServiceShouldReturnContentTypeFilterListenerInstance(): void
     {
         /** @var ContentNegotiationOptions|ObjectProphecy $options */
         $options = $this->prophesize(ContentNegotiationOptions::class);

--- a/test/Factory/RenameUploadFilterFactoryTest.php
+++ b/test/Factory/RenameUploadFilterFactoryTest.php
@@ -22,7 +22,7 @@ class RenameUploadFilterFactoryTest extends TestCase
         $this->filters = new FilterPluginManager(new ServiceManager(), $config);
     }
 
-    public function testMultipleFilters()
+    public function testMultipleFilters(): void
     {
         $optionsFilterOne = [
             'target' => 'SomeDir',

--- a/test/Filter/RenameUploadTest.php
+++ b/test/Filter/RenameUploadTest.php
@@ -94,7 +94,7 @@ class RenameUploadTest extends TestCase
     /**
      * @dataProvider uploadMethods
      */
-    public function testMoveUploadedFileSucceedsOnPutAndPatchHttpRequests(string $method)
+    public function testMoveUploadedFileSucceedsOnPutAndPatchHttpRequests(string $method): void
     {
         $target  = $this->targetDir . DIRECTORY_SEPARATOR . 'uploaded.txt';
         $file    = $this->createUploadFile();

--- a/test/HttpMethodOverrideListenerTest.php
+++ b/test/HttpMethodOverrideListenerTest.php
@@ -52,7 +52,7 @@ class HttpMethodOverrideListenerTest extends TestCase
     /**
      * @dataProvider httpMethods
      */
-    public function testHttpMethodOverrideListener(string $method)
+    public function testHttpMethodOverrideListener(string $method): void
     {
         $listener = $this->listener;
 
@@ -64,14 +64,14 @@ class HttpMethodOverrideListenerTest extends TestCase
         $event->setRequest($request);
         $event->setRouteMatch($this->createRouteMatch([]));
 
-        $result = $listener->onRoute($event);
+        $listener->onRoute($event);
         $this->assertEquals($method, $request->getMethod());
     }
 
     /**
      * @dataProvider httpMethods
      */
-    public function testHttpMethodOverrideListenerReturnsProblemResponseForMethodNotInConfig(string $method)
+    public function testHttpMethodOverrideListenerReturnsProblemResponseForMethodNotInConfig(string $method): void
     {
         $listener = $this->listener;
 
@@ -95,7 +95,7 @@ class HttpMethodOverrideListenerTest extends TestCase
     /**
      * @dataProvider httpMethods
      */
-    public function testHttpMethodOverrideListenerReturnsProblemResponseForIllegalOverrideValue(string $method)
+    public function testHttpMethodOverrideListenerReturnsProblemResponseForIllegalOverrideValue(string $method): void
     {
         $listener = $this->listener;
 

--- a/test/JsonModelTest.php
+++ b/test/JsonModelTest.php
@@ -15,20 +15,20 @@ use function pack;
 
 class JsonModelTest extends TestCase
 {
-    public function testSetVariables()
+    public function testSetVariables(): void
     {
         $jsonModel = new JsonModel(new TestAsset\ModelWithJson());
         $this->assertEquals('bar', $jsonModel->getVariable('foo'));
     }
 
-    public function testJsonModelIsAlwaysTerminal()
+    public function testJsonModelIsAlwaysTerminal(): void
     {
         $jsonModel = new JsonModel([]);
         $jsonModel->setTerminal(false);
         $this->assertTrue($jsonModel->terminate());
     }
 
-    public function testWillPullHalEntityFromPayloadToSerialize()
+    public function testWillPullHalEntityFromPayloadToSerialize(): void
     {
         $jsonModel = new JsonModel([
             'payload' => new HalEntity(['id' => 2, 'title' => 'Hello world'], 1),
@@ -42,7 +42,7 @@ class JsonModelTest extends TestCase
         $this->assertEquals('Hello world', $data['title']);
     }
 
-    public function testWillPullHalCollectionFromPayloadToSerialize()
+    public function testWillPullHalCollectionFromPayloadToSerialize(): void
     {
         $collection = [
             ['foo' => 'bar'],
@@ -58,7 +58,7 @@ class JsonModelTest extends TestCase
         $this->assertEquals($collection, $data);
     }
 
-    public function testWillRaiseExceptionIfErrorOccursEncodingJson()
+    public function testWillRaiseExceptionIfErrorOccursEncodingJson(): void
     {
         // Provide data that cannot be serialized to JSON
         $data      = ['foo' => pack('H*', 'c32e')];
@@ -70,7 +70,7 @@ class JsonModelTest extends TestCase
     /**
      * @group 17
      */
-    public function testCanSerializeTraversables()
+    public function testCanSerializeTraversables(): void
     {
         $variables = [
             'some'   => 'content',

--- a/test/RequestTest.php
+++ b/test/RequestTest.php
@@ -18,29 +18,29 @@ class RequestTest extends TestCase
         $this->request = new Request();
     }
 
-    public function testIsAnHttpRequest()
+    public function testIsAnHttpRequest(): void
     {
         $this->assertInstanceOf(\Laminas\Http\Request::class, $this->request);
     }
 
-    public function testIsAPhpEnvironmentHttpRequest()
+    public function testIsAPhpEnvironmentHttpRequest(): void
     {
         $this->assertInstanceOf(\Laminas\Http\PhpEnvironment\Request::class, $this->request);
     }
 
-    public function testDefinesAGetContentAsStreamMethod()
+    public function testDefinesAGetContentAsStreamMethod(): void
     {
         $this->assertTrue(method_exists($this->request, 'getContentAsStream'));
     }
 
-    public function testDefaultContentStreamIsPhpInputStream()
+    public function testDefaultContentStreamIsPhpInputStream(): void
     {
         $property = $this->getContentStreamReflectionProperty();
 
         $this->assertSame('php://input', $property->getValue($this->request));
     }
 
-    public function testCanSetStreamUriForContent()
+    public function testCanSetStreamUriForContent(): void
     {
         $property = $this->getContentStreamReflectionProperty();
 
@@ -50,14 +50,14 @@ class RequestTest extends TestCase
         $this->assertSame($expected, $property->getValue($this->request));
     }
 
-    public function testGetContentAsStreamReturnsResource()
+    public function testGetContentAsStreamReturnsResource(): void
     {
         $this->request->setContentStream('file://' . realpath(__FILE__));
         $stream = $this->request->getContentAsStream();
         $this->assertIsResource($stream);
     }
 
-    public function testReturnsPhpTemporaryStreamIfContentHasAlreadyBeenRetrieved()
+    public function testReturnsPhpTemporaryStreamIfContentHasAlreadyBeenRetrieved(): void
     {
         $r = new ReflectionObject($this->request);
         $p = $r->getProperty('content');

--- a/test/Validator/UploadFileTest.php
+++ b/test/Validator/UploadFileTest.php
@@ -32,7 +32,7 @@ class UploadFileTest extends TestCase
     /**
      * @dataProvider uploadMethods
      */
-    public function testDoesNotMarkUploadFileAsInvalidForPutAndPatchHttpRequests(string $method)
+    public function testDoesNotMarkUploadFileAsInvalidForPutAndPatchHttpRequests(string $method): void
     {
         $request = new HttpRequest();
         $request->setMethod($method);


### PR DESCRIPTION
This patch adds Psalm as part of the CI toolchain, by accomplishing the following steps:

- Adding Psalm and its PHPUnit plugin as dev dependencies.
- Adding a Psalm configuration file.
- Applying automated fixes as suggested by Psalm.
- Establishing an initial Psalm baseline file.

Fixes #13
